### PR TITLE
Minor tweaks to zephyr-memfault-example

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -1,8 +1,10 @@
-#include <zephyr/device.h>
-#include <zephyr/devicetree.h>
-#include <zephyr/drivers/gpio.h>
-#include <zephyr/logging/log.h>
-#include <zephyr/zephyr.h>
+//! @file
+
+#include <device.h>
+#include <devicetree.h>
+#include <drivers/gpio.h>
+#include <logging/log.h>
+#include <zephyr.h>
 
 #include "memfault/components.h"
 

--- a/west.yml
+++ b/west.yml
@@ -14,7 +14,10 @@ manifest:
     - name: zephyr
       remote: zephyrproject-rtos
       revision: zephyr-v3.1.0
-      import: true
+      import:
+        path-blocklist: modules/*
+        path-allowlist: modules/lib/memfault-firmware-sdk/
+        path-allowlist: modules/hal/cmsis
 
     # The Memfault SDK
     - name: memfault-firmware-sdk


### PR DESCRIPTION
1. Remove zephyr/* include structure for compatibility with old
   versions of Zephyr, :sadpanda:
2. Use blocklist feature in manifest for faster setup times when
   running "west update" by excluding a bunch of unused repos